### PR TITLE
Add a snap package (https://snapcraft.io)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,16 @@
     },
     "linux": {
       "category": "Network",
-      "target": ["AppImage", "deb", "rpm", "zip", "tar.xz", "tar.gz", "tar.bz2"]
+      "target": [
+        "snap",
+        "AppImage",
+        "deb",
+        "rpm",
+        "zip",
+        "tar.xz",
+        "tar.gz",
+        "tar.bz2"
+      ]
     }
   },
   "engines": {
@@ -43,6 +52,7 @@
   },
   "license": "GPL-3.0",
   "devDependencies": {
+    "electron-builder": "^19.53.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-node": "^5.2.1",


### PR DESCRIPTION
Hi! I put together this PR to add a [snap](https://snapcraft.io) package. I've tested it on Ubuntu 17.10 but it should work just as well on Ubuntu 14.04, 16.04, Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and `npm run dist` it will create `dist/unofficial-zalo_1.0.2_amd64.snap`.

Copy this to a Linux system, [enable snap support](https://docs.snapcraft.io/core/install), then run:
`sudo snap install --dangerous unofficial-zalo_1.0.2_amd64.snap`

Run with `unofficial-zalo` or find it in the launcher.

If you create a developer account and push this to the Snap Store, it can be discovered and installed through GNOME Software and https://snapcraft.io/discover. To create the developer account, [sign up here](https://dashboard.snapcraft.io/dev/account/), then [register the "unofficial-zalo" name](https://dashboard.snapcraft.io/register-snap/?name=unofficial-zalo).

You'll need the `snapcraft` command to push the snap file to the store.
* If you're on a Mac, you can `brew install snapcraft`
* If you're on Linux, it's `sudo snap install --classic snapcraft`

Then you can push Unofficial Zalo out with:
`snapcraft push unofficial-zalo_1.0.2_amd64.snap --release stable`

(You can also push to the Snap Store [programatically from Travis](https://docs.snapcraft.io/build-snaps/ci-integration#using-travis).)
  
  
  
  